### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -22,7 +22,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
     - name: Publish to docker repository
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
           name: kkaoeu/kktest:${{ secrets.FRONT_VERSION }} 
           repository: kkaoeu/kktest


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore